### PR TITLE
Prefer Power Grid copper wire, to avoid conflicts with Immersive Engineering.

### DIFF
--- a/config/almostunified/unification/materials.json
+++ b/config/almostunified/unification/materials.json
@@ -1,12 +1,15 @@
 {
   "mod_priorities": [
     "minecraft",
-    "crafttweaker",
+    "kubejs",
     "create",
+    "powergrid",
     "immersiveengineering",
     "oritech"
   ],
-  "priority_overrides": {},
+  "priority_overrides": {
+      "#c:wires/copper": "powergrid"
+  },
   "stone_variants": [
     "stone",
     "andesite",


### PR DESCRIPTION
Fixes #95.